### PR TITLE
Changes from testing with github actions for deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,20 +8,20 @@ on:
 jobs:
   Build-Push-Image:
     runs-on: windows-latest
-    steps: 
-      - name: Check out repository code
+    steps:
+      - name: Check out the repo
         uses: actions/checkout@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - run: docker image ls
-      - run: docker pull mcr.microsoft.com/windows/servercore:ltsc2022
-      - run: docker image ls
-
-      - name: Build docker image
-        run: docker build -t matteoschmider/winget:latest -f winget.Dockerfile .
-
-      - name: Login to docker hub
-        run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }} hub.docker.com
-
-      - name: Push image to docker hub
-        run: docker push matteoschmider/winget:latest
-
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: winget.Dockerfile
+          push: true
+          tags: matteoschmider/winget:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
       
       - run: docker image ls
-      - run: docker system prune -a
+      - run: docker system prune --all --force
       - run: docker image ls
 
       - name: Build docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,20 @@ on:
 jobs:
   Build-Push-Image:
     runs-on: windows-latest
-    container:
-      image: mcr.microsoft.com/windows/servercore:ltsc2022
-
     steps: 
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - run: dir
+      - run: docker image ls
+      - run: docker pull mcr.microsoft.com/windows/servercore:ltsc2022
+      - run: docker image ls
+
+      - name: Build docker image
+        run: docker build -t matteoschmider/winget:latest -f winget.Dockerfile .
+
+      - name: Login to docker hub
+        run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }} hub.docker.com
+
+      - name: Push image to docker hub
+        run: docker push matteoschmider/winget:latest
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
         uses: actions/checkout@v4
 
       - run: docker image ls
-      - run: docker pull mcr.microsoft.com/windows:ltsc2019
+      - run: docker pull mcr.microsoft.com/windows/server:ltsc2022
+      - run: docker image ls
 
       - name: Build docker image
         run: docker build -t matteoschmider/winget:latest -f winget.Dockerfile .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Build-Push-Image:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
       - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - run: docker pull mcr.microsoft.com/windows:ltsc2019
+
       - name: Build docker image
-        run: dir && docker build -t matteoschmider/winget:latest -f winget.Dockerfile .
+        run: docker build -t matteoschmider/winget:latest -f winget.Dockerfile .
 
       - name: Login to docker hub
         run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }} hub.docker.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -19,7 +20,7 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: winget.Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,20 +8,11 @@ on:
 jobs:
   Build-Push-Image:
     runs-on: windows-latest
+    container:
+      image: mcr.microsoft.com/windows:ltsc2022
+
     steps: 
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - run: docker image ls
-      - run: docker pull mcr.microsoft.com/windows/server:ltsc2022
-      - run: docker image ls
-
-      - name: Build docker image
-        run: docker build -t matteoschmider/winget:latest -f winget.Dockerfile .
-
-      - name: Login to docker hub
-        run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }} hub.docker.com
-
-      - name: Push image to docker hub
-        run: docker push matteoschmider/winget:latest
-
+      - run: dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,25 +7,17 @@ on:
 
 jobs:
   Build-Push-Image:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+      
+      - name: Build & push Docker image
+        uses: mr-smithers-excellent/docker-build-push@v6
         with:
+          registry: docker.io
+          image: matteoschmider/winget
+          tags: latest
+          dockerfile: winget.Dockerfile
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: winget.Dockerfile
-          push: true
-          tags: matteoschmider/winget:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Build-Push-Image:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 run-name: build and push docker image as latest to hub.docker.com/r/matteoschmider/winget as latest
 on:
-  push
-#  release:
-#    types: [created, edited]
+  release:
+    types: [created, edited]
 
 jobs:
   Build-Push-Image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - run: docker image ls
       - run: docker pull mcr.microsoft.com/windows:ltsc2019
 
       - name: Build docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   Build-Push-Image:
     runs-on: windows-latest
     container:
-      image: mcr.microsoft.com/windows:ltsc2022
+      image: mcr.microsoft.com/windows/servercore:ltsc2022
 
     steps: 
       - name: Check out repository code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
     steps: 
       - name: Check out repository code
         uses: actions/checkout@v4
+      
+      - run: docker image ls
+      - run: docker system prune -a
+      - run: docker image ls
 
       - name: Build docker image
         run: docker build -t matteoschmider/winget:latest -f winget.Dockerfile .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 run-name: build and push docker image as latest to hub.docker.com/r/matteoschmider/winget as latest
 on:
-  release:
-    types: [created, edited]
+  push
+#  release:
+#    types: [created, edited]
+
 jobs:
   Build-Push-Image:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,9 @@ jobs:
     steps: 
       - name: Check out repository code
         uses: actions/checkout@v4
-      
-      - run: docker image ls
-      - run: docker system prune --all --force
-      - run: docker image ls
 
       - name: Build docker image
-        run: docker build -t matteoschmider/winget:latest -f winget.Dockerfile .
+        run: dir && docker build -t matteoschmider/winget:latest -f winget.Dockerfile .
 
       - name: Login to docker hub
         run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }} hub.docker.com

--- a/winget.Dockerfile
+++ b/winget.Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/windows:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 ADD "build-winget.bat" "C:\build-winget.bat"
 RUN "C:\build-winget.bat"

--- a/winget.Dockerfile
+++ b/winget.Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 ADD "build-winget.bat" "C:\build-winget.bat"
 RUN "C:\build-winget.bat"

--- a/winget.Dockerfile
+++ b/winget.Dockerfile
@@ -1,3 +1,4 @@
 FROM mcr.microsoft.com/windows:ltsc2019
+RUN dir
 ADD "build-winget.bat" "C:\build-winget.bat"
 RUN "C:\build-winget.bat"

--- a/winget.Dockerfile
+++ b/winget.Dockerfile
@@ -1,4 +1,3 @@
-FROM mcr.microsoft.com/windows:ltsc2019
-RUN dir
+FROM mcr.microsoft.com/windows/server:ltsc2022
 ADD "build-winget.bat" "C:\build-winget.bat"
 RUN "C:\build-winget.bat"

--- a/winget.Dockerfile
+++ b/winget.Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows:ltsc2019
 ADD "build-winget.bat" "C:\build-winget.bat"
 RUN "C:\build-winget.bat"

--- a/winget.Dockerfile
+++ b/winget.Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/windows/server:ltsc2022
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 ADD "build-winget.bat" "C:\build-winget.bat"
 RUN "C:\build-winget.bat"


### PR DESCRIPTION
Testing revealed that Github Actions is only able to build docker images based on windows servercore at the most when using the windows runner.
This branch can now successfully build and push images using servercore as base.